### PR TITLE
Update JLink flashing script to take into account variable flash origin

### DIFF
--- a/toolchain/efm32-base.cmake
+++ b/toolchain/efm32-base.cmake
@@ -10,6 +10,10 @@ function(efm32_configure_linker_addresses target)
         target_link_options(${target}
             PRIVATE "LINKER:--defsym=flash_origin=${FLASH_ORIGIN}"
             )
+    else()
+        # We always need to set FLASH_ORIGIN so that the script
+        # toolchain/flash.in gets configured correctly.
+        set(FLASH_ORIGIN 0x00000000 PARENT_SCOPE)
     endif()
 
     if(FLASH_LENGTH)

--- a/toolchain/flash.in
+++ b/toolchain/flash.in
@@ -1,7 +1,7 @@
 device ${DEVICE}
 h
-loadbin ${BINARY}, ${FLASH_START}
-verifybin ${BINARY}, ${FLASH_START}
+loadbin ${BINARY}, ${FLASH_ORIGIN}
+verifybin ${BINARY}, ${FLASH_ORIGIN}
 r
 g
 qc


### PR DESCRIPTION
This is something that I missed in https://github.com/ryankurte/efm32-base/pull/10.