### PR TITLE
Add CPU family detection for MG21/BG21/BG22

### DIFF
--- a/toolchain/efm32-base.cmake
+++ b/toolchain/efm32-base.cmake
@@ -87,6 +87,11 @@ elseif (CPU_FAMILY_U STREQUAL "EFM32WG" OR CPU_FAMILY_U STREQUAL "EZR32WG"
     message("Architecture: cortex-m4")
     set(CPU_TYPE "m4")
     set(CPU_FIX "")
+elseif (CPU_FAMILY_U STREQUAL "EFR32MG21" OR CPU_FAMILY_U STREQUAL "EFR32BG21"
+        OR CPU_FAMILY_U STREQUAL "EFR32MG22")
+    message("Architecture: cortex-m33")
+    set(CPU_TYPE "m33")
+    set(CPU_FIX "-march=armv8-m.main+dsp -mcmse -mfpu=fpv5-sp-d16 -mfloat-abi=hard -falign-functions=2")
 else ()
     message("Architecture: cortex-m3 (default)")
     set(CPU_TYPE "m3")


### PR DESCRIPTION
This adds CPU family detection for the Wireless Cortex M33 chips recently released.
I've tested it on a custom EFR32MG21 board.

The compile flags are taken from SimplicityStudio's default compile flags. It feels kind of odd to put them in CPU_FIX variable, but wasn't sure where else to put them.