### PR TITLE
Add EFM32TG11B support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,19 @@ include(${BASE_LOCATION}/toolchain/arm-gcc.cmake)
 # Configure project and languages
 project(efm32-test C CXX ASM)
 
-# Set device
+# ${DEVICE} sets the target specific model name
 if (NOT DEVICE)
     set(DEVICE EFM32G210F128)
     # set(DEVICE BGM13P22F512GA)
     # set(BOARD BRD4306A)
     # set(BLE_LIB EFR32BG13P)
 endif ()
+
+# ${JLINK_DEVICE} device model setting specifically for JLink. (Defaults to ${DEVICE} when not set)
+# set(JLINK_DEVICE EFM32TG11BXXXF128)
+
+# When ${JLINK_SERVER_IP} is set, JLink will try to connect over IP to a JLink server
+# set(JLINK_SERVER_IP 127.0.0.1)
 
 # Set build
 if (NOT CMAKE_BUILD_TYPE)

--- a/toolchain/efm32-base.cmake
+++ b/toolchain/efm32-base.cmake
@@ -73,7 +73,7 @@ message("Family: ${CPU_FAMILY_U}")
 
 # Determine core type
 # TODO: find a neater (array based) way of doing this
-if (CPU_FAMILY_U STREQUAL "EFM32ZG" OR CPU_FAMILY_U STREQUAL "EFM32HG")
+if (CPU_FAMILY_U STREQUAL "EFM32ZG" OR CPU_FAMILY_U STREQUAL "EFM32HG" OR CPU_FAMILY_U STREQUAL "EFM32TG11B")
     message("Architecture: cortex-m0plus")
     set(CPU_TYPE "m0plus")
     set(CPU_FIX "")

--- a/toolchain/flash.in
+++ b/toolchain/flash.in
@@ -1,4 +1,4 @@
-device ${DEVICE}
+device ${JLINK_DEVICE}
 h
 loadbin ${BINARY}, ${FLASH_ORIGIN}
 verifybin ${BINARY}, ${FLASH_ORIGIN}

--- a/toolchain/jlink.cmake
+++ b/toolchain/jlink.cmake
@@ -7,6 +7,14 @@
 set(BINARY ${PROJECT_NAME}.bin)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/flash.in ${CMAKE_CURRENT_BINARY_DIR}/flash.jlink)
 
+if(JLINK_SERVER_IP)
+	set(JLINK_IP_ARG -ip ${JLINK_SERVER_IP})
+endif()
+
+if (NOT JLINK_DEVICE)
+    set(JLINK_DEVICE ${DEVICE})
+endif ()
+
 #Add JLink commands
 add_custom_target(debug
         COMMAND ${DEBUGGER} -tui -command ${CMAKE_CURRENT_LIST_DIR}/remote.gdbconf ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
@@ -14,7 +22,7 @@ add_custom_target(debug
 	)
 
 add_custom_target(debug-server 
-	COMMAND JLinkGDBServer -device ${DEVICE} -speed 4000 -if SWD
+	COMMAND JLinkGDBServer -device ${JLINK_DEVICE} -speed 4000 -if SWD
         DEPENDS ${PROJECT_NAME}
 	)
 
@@ -24,33 +32,32 @@ add_custom_target(d
 	)
 
 add_custom_target(ds
-	COMMAND JLinkGDBServer -device ${DEVICE} -speed 4000 -if SWD
+	COMMAND JLinkGDBServer -device ${JLINK_DEVICE} -speed 4000 -if SWD
         DEPENDS ${PROJECT_NAME}
 	)
 
 add_custom_target(flash 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_BINARY_DIR}/flash.jlink
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_BINARY_DIR}/flash.jlink
         DEPENDS ${PROJECT_NAME}
 	)
 
 add_custom_target(f 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_BINARY_DIR}/flash.jlink
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_BINARY_DIR}/flash.jlink
         DEPENDS ${PROJECT_NAME}
 	)
 
-
 add_custom_target(erase 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/erase.jlink 
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/erase.jlink 
 	)
 
 add_custom_target(e 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/erase.jlink 
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/erase.jlink 
 	)
 
 add_custom_target(reset 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/reset.jlink 
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/reset.jlink 
 	)
 
 add_custom_target(r 
-	COMMAND JLinkExe -device ${DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/reset.jlink 
+	COMMAND JLinkExe ${JLINK_IP_ARG} -device ${JLINK_DEVICE} -speed 4000 -if SWD -CommanderScript ${CMAKE_CURRENT_LIST_DIR}/reset.jlink 
 	)


### PR DESCRIPTION
I'm using the new(er) EFM32 part from the EFM32TG11B series. First commit adds support, setting the correct core type (Cortex M0+)
Also for this device class, JLink needs a different device designator (e.g. EFM32TG11BXXXF128 for a EFM32TG11B120F128GQ48 part). Included a variable to set JLink device separately: `JLINK_DEVICE`

As I'm building my firmware on Windows (WSL), for flashing using a JLink server. Added a `JLINK_SERVER_IP` variable for using a remote JLink server (in my case the native JLink server running on Windows).